### PR TITLE
Support Rails 6.1: fixes undefined method `write_attribute`

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -20,6 +20,7 @@ jobs:
     strategy:
       matrix:
         ruby-version: ['2.6', '2.7', '3.0']
+        rails-version: ['6.0', '6.1']
         mongodb-version: ['4.4']
         sqlite-version: ['3.0']
 
@@ -32,6 +33,8 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby-version }}
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+      env:
+        TEST_RAILS_VERSION: ${{ matrix.rails-version }}
 
     - name: Start MongoDB
       uses: supercharge/mongodb-github-action@1.3.0

--- a/Gemfile
+++ b/Gemfile
@@ -28,3 +28,12 @@ group :development do
   gem 'guard-rspec'
   gem 'guard-rails'
 end
+
+case ENV['TEST_RAILS_VERSION']
+when "6.0"
+  gem "activesupport", "~> 6.0.4"
+when "6.1"
+  gem "activesupport", "~> 6.1.4"
+when "7.0"
+  gem "activesupport", "~> 7.0.4"
+end

--- a/lib/money-rails/active_model/attributes.rb
+++ b/lib/money-rails/active_model/attributes.rb
@@ -1,0 +1,17 @@
+module MoneyRails
+  module ActiveModel
+    module Attributes
+      private
+
+      if Gem::Version.new(Rails.version) >= Gem::Version.new("6.1")
+        def _write_attribute(*args)
+          super(*args)
+        end
+
+        def write_attribute(*args)
+          _write_attribute(*args)
+        end
+      end
+    end
+  end
+end

--- a/lib/money-rails/railtie.rb
+++ b/lib/money-rails/railtie.rb
@@ -3,5 +3,12 @@ module MoneyRails
     initializer 'moneyrails.initialize', after: 'active_record.initialize_database' do
       MoneyRails::Hooks.init
     end
+
+    config.to_prepare do |_app|
+      ActiveSupport.on_load(:active_record) do
+        require_relative "active_model/attributes"
+        ::ActiveModel::Attributes.prepend(MoneyRails::ActiveModel::Attributes)
+      end
+    end
   end
 end

--- a/lib/money-rails/version.rb
+++ b/lib/money-rails/version.rb
@@ -1,3 +1,3 @@
 module MoneyRails
-  VERSION = '1.15.0'
+  VERSION = '1.16.0'
 end

--- a/spec/active_record/monetizable_spec.rb
+++ b/spec/active_record/monetizable_spec.rb
@@ -105,6 +105,24 @@ if defined? ActiveRecord
         expect(transaction.amount_cents).to eq(20000)
       end
 
+      it "does not raise exception on value assignment to attribute" do
+        class Price
+          include ActiveModel::Model
+          include ActiveModel::Attributes
+          include ActiveModel::AttributeMethods
+          include MoneyRails::ActiveRecord::Monetizable
+
+          define_model_callbacks :save,  only: [:after]
+
+          attribute :value_cents, :integer
+
+          monetize :value_cents
+        end
+
+        price = Price.new(value_cents: 12)
+        expect { price.value = 10 }.not_to raise_error
+      end
+
       it "raises an error if trying to create two attributes with the same name" do
         expect do
           class Product


### PR DESCRIPTION
This MR fixes NoMethodError (undefined method `write_attribute` for `#<TestModel:XXXX>`